### PR TITLE
patches for qt-creator trunk (and 3.4)

### DIFF
--- a/boostbuildprojectmanager/bbbuildconfiguration.cpp
+++ b/boostbuildprojectmanager/bbbuildconfiguration.cpp
@@ -18,7 +18,6 @@
 #include "bbutility.hpp"
 // Qt Creator
 #include <coreplugin/icore.h>
-#include <coreplugin/mimedatabase.h>
 #include <projectexplorer/buildinfo.h>
 #include <projectexplorer/buildsteplist.h>
 #include <projectexplorer/projectexplorerconstants.h>
@@ -29,6 +28,8 @@
 #include <utils/pathchooser.h>
 #include <utils/fileutils.h>
 #include <utils/qtcassert.h>
+#include <utils/mimetypes/mimedatabase.h>
+
 // Qt
 #include <QFileInfo>
 #include <QFormLayout>
@@ -163,8 +164,10 @@ BuildConfigurationFactory::priority(ProjectExplorer::Kit const* k
 {
     BBPM_QDEBUG(k->displayName() << ", " << projectPath);
 
-    Core::MimeType const mt = Core::MimeDatabase::findByFile(QFileInfo(projectPath));
-    return (k && mt.matchesType(QLatin1String(Constants::MIMETYPE_JAMFILE)))
+    Utils::MimeDatabase mdb;
+    Utils::MimeType mimeType = mdb.mimeTypeForFile(QFileInfo(projectPath));
+
+    return (k && mimeType.matchesName(QLatin1String(Constants::MIMETYPE_JAMFILE)))
             ? 0
             : -1;
 }

--- a/boostbuildprojectmanager/bbopenprojectwizard.cpp
+++ b/boostbuildprojectmanager/bbopenprojectwizard.cpp
@@ -18,11 +18,11 @@
 // Qt Creator
 #include <coreplugin/iwizardfactory.h>
 #include <coreplugin/icore.h>
-#include <coreplugin/mimedatabase.h>
 #include <projectexplorer/customwizard/customwizard.h>
 #include <projectexplorer/projectexplorerconstants.h>
 #include <utils/pathchooser.h>
 #include <utils/qtcassert.h>
+#include <utils/mimetypes/mimedatabase.h>
 // Qt
 #include <QFileInfo>
 #include <QFormLayout>
@@ -95,11 +95,13 @@ OpenProjectWizard::generateFiles(QWizard const* wizard, QString* errorMessage) c
     QStringList headerFilters;
     QStringList const headerMimeTypes = QStringList()
         << QLatin1String("text/x-chdr") << QLatin1String("text/x-c++hdr");
+
+    Utils::MimeDatabase mdb;
     foreach (QString const& headerMime, headerMimeTypes)
     {
-        Core::MimeType mime = Core::MimeDatabase::findByType(headerMime);
-        foreach (Core::MimeGlobPattern const& gp, mime.globPatterns())
-            headerFilters.append(gp.pattern());
+        Utils::MimeType mime = mdb.mimeTypeForName(headerMime);
+        foreach (QString const& gp, mime.globPatterns())
+            headerFilters.append(gp);
     }
 
     // Generate list of include paths.

--- a/boostbuildprojectmanager/bbproject.cpp
+++ b/boostbuildprojectmanager/bbproject.cpp
@@ -24,7 +24,6 @@
 #include <coreplugin/icontext.h>
 #include <coreplugin/icore.h>
 #include <coreplugin/generatedfile.h>
-#include <coreplugin/mimedatabase.h>
 #include <coreplugin/progressmanager/progressmanager.h>
 #include <cpptools/cppmodelmanager.h>
 #include <cpptools/cppprojects.h>

--- a/boostbuildprojectmanager/bbprojectmanagerplugin.cpp
+++ b/boostbuildprojectmanager/bbprojectmanagerplugin.cpp
@@ -20,7 +20,8 @@
 #include <coreplugin/actionmanager/command.h>
 #include <coreplugin/actionmanager/actioncontainer.h>
 #include <coreplugin/coreconstants.h>
-#include <coreplugin/mimedatabase.h>
+#include <utils/mimetypes/mimedatabase.h>
+// Qt
 #include <QAction>
 #include <QMessageBox>
 #include <QMainWindow>
@@ -44,6 +45,7 @@ BoostBuildPlugin::~BoostBuildPlugin()
 bool BoostBuildPlugin::initialize(QStringList const& arguments, QString* errorString)
 {
     Q_UNUSED(arguments)
+    Q_UNUSED(errorString)
 
     // Register objects in the plugin manager's object pool
     // Load settings
@@ -53,8 +55,7 @@ bool BoostBuildPlugin::initialize(QStringList const& arguments, QString* errorSt
     // depends on have initialized their members.
 
     QLatin1String const mimeTypes(":boostbuildproject/BoostBuildProjectManager.mimetypes.xml");
-    if (!Core::MimeDatabase::addMimeTypes(mimeTypes, errorString))
-        return false;
+    Utils::MimeDatabase::addMimeTypes(mimeTypes);
 
     addAutoReleasedObject(new BuildStepFactory);
     addAutoReleasedObject(new BuildConfigurationFactory);

--- a/boostbuildprojectmanager/bbprojectnode.cpp
+++ b/boostbuildprojectmanager/bbprojectnode.cpp
@@ -29,7 +29,7 @@ namespace BoostBuildProjectManager {
 namespace Internal {
 
 ProjectNode::ProjectNode(Project* project, Core::IDocument* projectFile)
-    : ProjectExplorer::ProjectNode(projectFile->filePath().toString())
+    : ProjectExplorer::ProjectNode(projectFile->filePath())
     , project_(project)
     , projectFile_(projectFile)
 {
@@ -109,15 +109,15 @@ void ProjectNode::refresh(QSet<QString> oldFileList)
     if (oldFileList.isEmpty())
     {
         using ProjectExplorer::FileNode;
-        FileNode* projectFileNode = new FileNode(project_->projectFilePath().toString()
+        FileNode* projectFileNode = new FileNode(project_->projectFilePath()
                                                , ProjectExplorer::ProjectFileType
                                                , Constants::FileNotGenerated);
 
-        FileNode* filesFileNode = new FileNode(project_->filesFilePath()
+        FileNode* filesFileNode = new FileNode(Utils::FileName::fromString(project_->filesFilePath())
                                              , ProjectExplorer::ProjectFileType
                                              , Constants::FileNotGenerated);
 
-        FileNode* includesFileNode = new FileNode(project_->includesFilePath()
+        FileNode* includesFileNode = new FileNode(Utils::FileName::fromString(project_->includesFilePath())
                                              , ProjectExplorer::ProjectFileType
                                              , Constants::FileNotGenerated);
 
@@ -142,7 +142,7 @@ void ProjectNode::refresh(QSet<QString> oldFileList)
     typedef FilesInPaths::ConstIterator FilesInPathsIterator;
     using ProjectExplorer::FileNode;
     using ProjectExplorer::FileType;
-    QString const baseDir = QFileInfo(path()).absolutePath();
+    QString const baseDir = QFileInfo(path().toString()).absolutePath();
 
     // Process all added files
     FilesInPaths filesInPaths = Utility::sortFilesIntoPaths(baseDir, added);
@@ -165,7 +165,7 @@ void ProjectNode::refresh(QSet<QString> oldFileList)
         {
             // TODO: handle various types, mime to FileType
             FileType fileType = ProjectExplorer::SourceType;
-            FileNode* fileNode = new FileNode(file, fileType, Constants::FileNotGenerated);
+            FileNode* fileNode = new FileNode(Utils::FileName::fromString(file), fileType, Constants::FileNotGenerated);
             fileNodes.append(fileNode);
         }
 
@@ -188,7 +188,7 @@ void ProjectNode::refresh(QSet<QString> oldFileList)
         foreach (QString const& file, it.value())
         {
             foreach (FileNode* fn, folder->fileNodes())
-                if (fn->path() == file)
+                if (fn->path() == Utils::FileName::fromString(file))
                     fileNodes.append(fn);
         }
 
@@ -228,9 +228,9 @@ ProjectNode::createFolderByName(QStringList const& components, int const end)
         return this;
 
     using ProjectExplorer::FolderNode;
-    QString const baseDir = QFileInfo(path()).path();
+    QString const baseDir = QFileInfo(path().toString()).path();
     QString const folderName = appendPathComponents(components, end);
-    FolderNode* folder = new FolderNode(baseDir + QLatin1Char('/') + folderName);
+    FolderNode* folder = new FolderNode(Utils::FileName::fromString(baseDir + QLatin1Char('/') + folderName));
     folder->setDisplayName(components.at(end - 1));
 
     FolderNode* parent = findFolderByName(components, end - 1);
@@ -253,10 +253,10 @@ ProjectNode::findFolderByName(QStringList const& components, int const end) cons
         return 0;
 
     QString const folderName = appendPathComponents(components, end);
-    QString const baseDir = QFileInfo(path()).path();
+    QString const baseDir = QFileInfo(path().toString()).path();
     foreach (FolderNode* fn, parent->subFolderNodes())
     {
-        if (fn->path() == baseDir + QLatin1Char('/') + folderName)
+        if (fn->path() == Utils::FileName::fromString(baseDir + QLatin1Char('/') + folderName))
             return fn;
     }
 

--- a/boostbuildprojectmanager/filesselectionwizardpage.cpp
+++ b/boostbuildprojectmanager/filesselectionwizardpage.cpp
@@ -38,13 +38,13 @@
 #include "bbprojectmanagerconstants.hpp"
 #include "selectablefilesmodel.hpp"
 
-#include <coreplugin/mimedatabase.h>
 #include <coreplugin/icore.h>
 #include <utils/pathchooser.h>
 
 #include <QVBoxLayout>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QFileInfo>
 
 namespace BoostBuildProjectManager {
 namespace Internal {


### PR DESCRIPTION
Adapt to change in QtCreator.
- changes in MimeData handling
- Some more explicit QString vs. Utils::Filename conversions
